### PR TITLE
Handle damage info safely after player death

### DIFF
--- a/lua/investigationmod/server/sv_hooks.lua
+++ b/lua/investigationmod/server/sv_hooks.lua
@@ -6,36 +6,40 @@ InvestigationMod.DeathBodies = {}
 	Doing this for the AMM compatibility
 ]]
 hook.Add( "DoPlayerDeath", "DoPlayerDeath.InvestigationMod", function( pVictim, pAttacker, cDamageInfos )
-	pVictim.IM_DeathInfo = {
-		Attacker = pAttacker,
-		DamageInfos = cDamageInfos
-	}
+        pVictim.IM_DeathInfo = {
+                Attacker = pAttacker,
+                DamageType = cDamageInfos and cDamageInfos:GetDamageType() or 0,
+                IsBullet = cDamageInfos and cDamageInfos:IsBulletDamage() or false,
+                AmmoType = cDamageInfos and cDamageInfos:GetAmmoType() or 0
+        }
 end )
 
 hook.Add( "PostPlayerDeath", "PostPlayerDeath.InvestigationMod", function( pVictim )
-	if not pVictim.IM_DeathInfo then return end
+        if not pVictim.IM_DeathInfo then return end
 
-	pAttacker = pVictim.IM_DeathInfo.Attacker
-	cDamageInfos = pVictim.IM_DeathInfo.DamageInfos
+        local pAttacker = pVictim.IM_DeathInfo.Attacker
+        local iDamageType = pVictim.IM_DeathInfo.DamageType
+        local bBullet = pVictim.IM_DeathInfo.IsBullet
+        local iAmmoType = pVictim.IM_DeathInfo.AmmoType
 
-	pVictim:IM_DeathBody( cDamageInfos, pAttacker )
-	pVictim.IM_DeathInfo = nil
+        pVictim:IM_DeathBody( iDamageType, pAttacker )
+        pVictim.IM_DeathInfo = nil
 
-	if not IsValid( pAttacker ) or not pAttacker:IsPlayer() or pAttacker == pVictim then return end
-	if cDamageInfos:IsBulletDamage() then
-		if not IsValid( pAttacker:GetActiveWeapon() ) or InvestigationMod.Configuration.DontDropBullet[ pAttacker:GetActiveWeapon():GetClass() ] then return end
+        if not IsValid( pAttacker ) or not pAttacker:IsPlayer() or pAttacker == pVictim then return end
+        if bBullet then
+                if not IsValid( pAttacker:GetActiveWeapon() ) or InvestigationMod.Configuration.DontDropBullet[ pAttacker:GetActiveWeapon():GetClass() ] then return end
 
-		pAttacker:IM_CreateBullet( pVictim:GetPos(), pAttacker:GetAngles(), pAttacker:GetActiveWeapon():GetModel(), pAttacker:GetActiveWeapon():GetClass(), cDamageInfos:GetAmmoType() )
-		pAttacker:IM_ShouldRegisterFootsteps( true )
-		pAttacker:IM_ShouldRegisterDoorFinger( true )
+                pAttacker:IM_CreateBullet( pVictim:GetPos(), pAttacker:GetAngles(), pAttacker:GetActiveWeapon():GetModel(), pAttacker:GetActiveWeapon():GetClass(), iAmmoType )
+                pAttacker:IM_ShouldRegisterFootsteps( true )
+                pAttacker:IM_ShouldRegisterDoorFinger( true )
 
-		timer.Simple( InvestigationMod:GetConfig( "Time_RegisterPrints" ), function() 
-			if IsValid( pAttacker ) then
-				pAttacker:IM_ShouldRegisterFootsteps( false )
-				pAttacker:IM_ShouldRegisterDoorFinger( false )
-			end
-		end )
-	end
+                timer.Simple( InvestigationMod:GetConfig( "Time_RegisterPrints" ), function()
+                        if IsValid( pAttacker ) then
+                                pAttacker:IM_ShouldRegisterFootsteps( false )
+                                pAttacker:IM_ShouldRegisterDoorFinger( false )
+                        end
+                end )
+        end
 end )
 
 hook.Add( "PlayerFootstep", "PlayerFootstep.InvestigationMod", function( pPlayer, vPos, iFoot ) 
@@ -63,20 +67,20 @@ end )
 hook.Add( "PlayerSpawn", "MedicMod.InvestigationMod", function( pPlayer )
 	if not ConfigurationMedicMod then return end
 
-	timer.Simple( 0.2, function()
-		if pPlayer.IM_tDamageInfos then
-			pPlayer:IM_DeathBody( pPlayer.IM_tDamageInfos.DamageInfos, pPlayer.IM_tDamageInfos.Criminal, pPlayer.IM_tDamageInfos.Pos, pPlayer.IM_tDamageInfos.Model )
-			pPlayer.IM_tDamageInfos = nil
-		end
-	end )
+        timer.Simple( 0.2, function()
+                if pPlayer.IM_tDamageInfos then
+                        pPlayer:IM_DeathBody( pPlayer.IM_tDamageInfos.DamageType, pPlayer.IM_tDamageInfos.Criminal, pPlayer.IM_tDamageInfos.Pos, pPlayer.IM_tDamageInfos.Model )
+                        pPlayer.IM_tDamageInfos = nil
+                end
+        end )
 end )
 
 hook.Add( "EntityRemoved", "MedicMod.InvestigationMod", function( eEntity )
 	if IsValid( eEntity ) and isfunction( eEntity.IsDeathRagdoll ) and eEntity:IsDeathRagdoll() then 
 		local pPlayer = eEntity:GetOwner()
-		if IsValid( pPlayer ) and pPlayer.IM_tDamageInfos then 
-			pPlayer.IM_tDamageInfos.Pos = eEntity:GetPos()
-		end
+                if IsValid( pPlayer ) and pPlayer.IM_tDamageInfos then
+                        pPlayer.IM_tDamageInfos.Pos = eEntity:GetPos()
+                end
 	end
 end )
 
@@ -98,12 +102,12 @@ end )
 ]]
 hook.Add( "CH_AdvMedic_OnBodyRemoved", "CH_Medic.InvestigationMod", function( pPlayer, bRevived )
 	if not bRevived then
-		timer.Simple( 0.2, function()
-			if pPlayer.IM_tDamageInfos then
-				pPlayer:IM_DeathBody( pPlayer.IM_tDamageInfos.DamageInfos, pPlayer.IM_tDamageInfos.Criminal, pPlayer.IM_tDamageInfos.Pos, pPlayer.IM_tDamageInfos.Model )
-				pPlayer.IM_tDamageInfos = nil
-			end
-		end )
+                timer.Simple( 0.2, function()
+                        if pPlayer.IM_tDamageInfos then
+                                pPlayer:IM_DeathBody( pPlayer.IM_tDamageInfos.DamageType, pPlayer.IM_tDamageInfos.Criminal, pPlayer.IM_tDamageInfos.Pos, pPlayer.IM_tDamageInfos.Model )
+                                pPlayer.IM_tDamageInfos = nil
+                        end
+                end )
 	else
 		timer.Simple( 1, function()
 			if IsValid( InvestigationMod.DeathBodies[ pPlayer ] ) then


### PR DESCRIPTION
## Summary
- avoid using CTakeDamageInfo after hooks by storing damage type and ammo info
- calculate death cause via damage type bitflags
- prioritize aimed clue when inspecting overlapping bodies and bullets

## Testing
- `luacheck lua/investigationmod/client/cl_functions.lua` *(264 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6899162fcba0832ca9f85f9facdd73dc